### PR TITLE
fixing the crash when running examples

### DIFF
--- a/bindings/sdl2-shim.c
+++ b/bindings/sdl2-shim.c
@@ -347,7 +347,8 @@ lean_obj_res lean_sdl_mk_sdl_rect(uint32_t x, uint32_t y, uint32_t w, uint32_t h
   r->y = y;
   r->w = w;
   r->h = h;
-  return lean_alloc_external(get_sdl_rect_class(), r);
+  lean_object *lean_t  = lean_alloc_external(get_sdl_rect_class(), r);
+  return lean_io_result_mk_ok(lean_t);
 }
 
 /*


### PR DESCRIPTION
Thanks for developing SDL bindings for Lean4!

I tried running the examples as described in the readme, and for `animation` and `event` examples the program would crash:

```
$ nix run .#test animation
Illegal instruction (core dumped)

$ nix run .#test event
Illegal instruction (core dumped)
```
It seems that sdl rect object needs to be wrapped when created, with this fix examples run fine for me.